### PR TITLE
Fix panic on empty character pool

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -30,7 +30,10 @@ impl PasswordGenerator {
         self.char_classes = char_classes;
     }
 
-    pub fn generate_password(&self) -> String {
+    /// Generate a password using the configured options. If after applying
+    /// the exclusion list no characters remain in the pool this will return an
+    /// error instead of panicking.
+    pub fn generate_password(&self) -> Result<String, &'static str> {
         let mut character_pool = String::new();
 
         // Add character sets based on selected character classes
@@ -52,15 +55,47 @@ impl PasswordGenerator {
             character_pool = character_pool.replace(c, "");
         }
 
+        if character_pool.is_empty() {
+            return Err("No characters available after exclusions");
+        }
+
         // Generate password of specified length
         let mut rng = rand::thread_rng();
         let password: String = (0..self.length)
             .map(|_| {
                 let idx = rng.gen_range(0..character_pool.len());
-                character_pool.chars().nth(idx).unwrap()
+                character_pool
+                    .chars()
+                    .nth(idx)
+                    .expect("index within bounds because character_pool isn't empty")
             })
             .collect();
 
-        password
+        Ok(password)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::iter::FromIterator;
+
+    #[test]
+    fn generate_password_empty_pool() {
+        let mut gen = PasswordGenerator::new();
+        gen.set_length(8);
+        gen.set_char_classes(HashSet::from_iter([CharClass::Numbers]));
+        gen.set_excluded_character_set("0123456789".to_string());
+        assert!(gen.generate_password().is_err());
+    }
+
+    #[test]
+    fn generate_password_success() {
+        let mut gen = PasswordGenerator::new();
+        gen.set_length(4);
+        gen.set_char_classes(HashSet::from_iter([CharClass::LowerLetters]));
+        let pwd = gen.generate_password().unwrap();
+        assert_eq!(pwd.len(), 4);
     }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -205,8 +205,17 @@ pub fn build_ui(app: &Application) {
 
             generator.set_char_classes(char_classes);
 
-            // Generate and display password
-            let password = generator.generate_password();
+            // Generate and display password. If generation fails (e.g. all
+            // characters were excluded) show the error to the user instead of
+            // panicking.
+            let password = match generator.generate_password() {
+                Ok(p) => p,
+                Err(e) => {
+                    error_label.set_visible(true);
+                    error_label.set_text(e);
+                    return;
+                }
+            };
             let buffer = result_textview.buffer();
             buffer.set_text(&password);
 


### PR DESCRIPTION
## Summary
- avoid panic when all characters are excluded
- surface error in GUI
- add unit tests for password generator

## Testing
- `cargo test` *(fails: `gio-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3e45977883308bed87106b9798c2